### PR TITLE
chore/remove redis inprocess runner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres:
     image: postgres:16-alpine
@@ -19,18 +17,6 @@ services:
       timeout: 5s
       retries: 20
 
-  redis:
-    image: redis:7-alpine
-    container_name: ${COMPOSE_PROJECT_NAME:-vlm}-redis
-    restart: unless-stopped
-    command: ["redis-server", "--save", "", "--appendonly", "no"]
-    ports:
-      - "${REDIS_PORT:-6379}:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 20
 
   minio:
     image: minio/minio:latest

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -9,9 +9,6 @@ docker compose up -d --wait
 echo "[healthcheck] Waiting for Postgres to be healthy..."
 docker compose ps postgres | grep -q "healthy"
 
-echo "[healthcheck] Waiting for Redis to be healthy..."
-docker compose ps redis | grep -q "healthy"
-
 echo "[healthcheck] Waiting for MinIO liveness..."
 # Poll MinIO HTTP liveness instead of compose health status
 for i in {1..60}; do
@@ -24,8 +21,7 @@ done
 echo "[healthcheck] Verifying Postgres connectivity..."
 docker compose exec -T postgres psql -U "${POSTGRES_USER:-vlm}" -d "${POSTGRES_DB:-vlm}" -c "SELECT 1;" >/dev/null
 
-echo "[healthcheck] Verifying Redis connectivity..."
-docker compose exec -T redis redis-cli ping | grep -q PONG
+:
 
 echo "[healthcheck] Verifying MinIO liveness endpoint..."
 curl -fsS "http://localhost:${MINIO_PORT_API:-9000}/minio/health/live" >/dev/null

--- a/src/lib/queue/bullmq.ts
+++ b/src/lib/queue/bullmq.ts
@@ -1,0 +1,37 @@
+// Simple in-process task runner for local/internal tooling.
+// Provides enqueue + drain with concurrency=1 semantics.
+
+export type Task<T> = () => Promise<T> | T
+
+export class TaskQueue {
+  private queue: Array<{ name: string; fn: Task<unknown> }>
+  private running: boolean
+
+  constructor() {
+    this.queue = []
+    this.running = false
+  }
+
+  enqueue<T>(name: string, fn: Task<T>) {
+    this.queue.push({ name, fn })
+    if (!this.running) {
+      void this.drain()
+    }
+  }
+
+  private async drain() {
+    this.running = true
+    try {
+      while (this.queue.length > 0) {
+        const item = this.queue.shift()!
+        await item.fn()
+      }
+    } finally {
+      this.running = false
+    }
+  }
+}
+
+export const defaultTaskQueue = new TaskQueue()
+
+


### PR DESCRIPTION
- **chore(m0): bootstrap Docker Compose for Postgres, Redis, MinIO with healthcheck and Makefile; update README**
- **docs: use Makefile in README; ci: add infra check workflow to start compose + healthcheck**
- **ci: fix compose health on MinIO; poll HTTP liveness; provide CI env file**
- **ci: allow manual run via workflow_dispatch**
- **ci: add eslint config and deps; fix lint step**
- **chore(prisma): add Prisma setup, minimal schema, db smoke test; ci: generate and migrate**
- **chore(prisma): add Node CJS db smoke script for CI/local**
- **chore(ci): add helper script to retrieve latest workflow run and logs**
- **chore(prisma): add initial migration for AppMeta**
- **chore(m0): add core schema v1 (text-only, gold answers) and migration**
- **chore(m0): add seed script and seed step to CI**
- **chore(ci): improve ci-last-run helper; fix core_schema migration to avoid duplicate AppMeta**
- **chore(m0): add typed config module with zod + health route; ci: add typecheck**
- **chore(m0): add S3/MinIO client abstraction with presigned URLs and storage API**
- **refactor: remove Redis/BullMQ; switch to in-process task runner; update compose, healthcheck, and design**
